### PR TITLE
Missing psycopg2 in timescales docker file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ docker-compose up -d zabbix
 
 docker-compose up -d zabbixweb
 
+# pgadmin for psql gui access
+docker-compose up -d pgadmin
+
 ```
 
 ## Setup Database Zabbix

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,46 +4,47 @@ services:
   timescaledb1:
     build: ./timescaledb
     container_name: scale_db_01
-    volumes: 
+    volumes:
         - ./timescaledb/conf/patroni.yml:/etc/patroni.yml
     #   - ./data:/var/lib/postgresql/data
-    environment: 
+    environment:
       - POSTGRES_PASSWORD=postgres
     networks:
       - timescaledb_cluster
-    depends_on: 
+    depends_on:
       - etcd
-  
+
   timescaledb2:
     build: ./timescaledb
     container_name: scale_db_02
-    volumes: 
+    volumes:
         - ./timescaledb/conf/patroni2.yml:/etc/patroni.yml
     #   - ./data:/var/lib/postgresql/data
-    environment: 
+    environment:
       - POSTGRES_PASSWORD=postgres
     networks:
       - timescaledb_cluster
-    depends_on: 
+    depends_on:
       - etcd
 
   timescaledb3:
     build: ./timescaledb
     container_name: scale_db_03
-    volumes: 
+    volumes:
         - ./timescaledb/conf/patroni3.yml:/etc/patroni.yml
     #   - ./data:/var/lib/postgresql/data
-    environment: 
+    environment:
       - POSTGRES_PASSWORD=postgres
     networks:
       - timescaledb_cluster
-    depends_on: 
+    depends_on:
       - etcd
 
   etcd:
     image: 'bitnami/etcd:latest'
     container_name: scale_etcd
     environment:
+      - ETCD_ENABLE_V2=true
       - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
     ports:
@@ -57,9 +58,9 @@ services:
   haproxy:
     image: haproxy:1.9.8-alpine
     container_name: scale_haproxy
-    volumes: 
+    volumes:
       - ./haproxy:/usr/local/etc/haproxy:ro
-    ports: 
+    ports:
       - 7000:7000
       - 5000:5000
     networks:
@@ -68,44 +69,44 @@ services:
   grafana:
     image: grafana/grafana
     container_name: scale_monitor
-    ports: 
+    ports:
       - 5500:3000
-    networks: 
+    networks:
       - timescaledb_cluster
-    depends_on: 
+    depends_on:
       - haproxy
 
   zabbix:
     image: zabbix/zabbix-server-pgsql
     container_name: scale_zabbix
-    ports: 
+    ports:
       - 10051:10051
-    environment: 
+    environment:
       - DB_SERVER_HOST=haproxy
       - DB_SERVER_PORT=5000
       - POSTGRES_DB=zabbix
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
-    networks: 
+    networks:
       - timescaledb_cluster
-    depends_on: 
+    depends_on:
       - haproxy
 
   zabbixweb:
     image: zabbix/zabbix-web-nginx-pgsql
     container_name: scale_zabbix_web
-    ports: 
-      - 10080:80
-    environment: 
+    ports:
+      - 10080:8080
+    environment:
       - ZBX_SERVER_HOST=zabbix
       - DB_SERVER_HOST=haproxy
       - DB_SERVER_PORT=5000
       - POSTGRES_DB=zabbix
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
-    networks: 
+    networks:
       - timescaledb_cluster
-    depends_on: 
+    depends_on:
       - zabbix
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,18 @@ services:
     depends_on:
       - zabbix
 
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin4
+    depends_on: 
+      - haproxy
+    ports:
+      - "53603:53603"
+      - "80:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: root
+
 networks:
   timescaledb_cluster:
     driver: bridge

--- a/timescaledb/Dockerfile
+++ b/timescaledb/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && apk --no-cache add gcc g++ libpq linux-headers curl
 RUN pip3 install --upgrade pi
 
 # install patroni
+RUN pip install psycopg2
 RUN pip install patroni
 RUN pip install python-etcd
 RUN ln -s /usr/local/bin/pg_* /usr/sbin/

--- a/timescaledb/Dockerfile
+++ b/timescaledb/Dockerfile
@@ -1,4 +1,5 @@
-FROM timescale/timescaledb:latest-pg11
+#FROM timescale/timescaledb:latest-pg11
+FROM timescale/timescaledb-postgis:1.3.1-pg11
 
 LABEL MAINTAINER BukTon
 

--- a/timescaledb/Dockerfile
+++ b/timescaledb/Dockerfile
@@ -1,5 +1,5 @@
-#FROM timescale/timescaledb:latest-pg11
-FROM timescale/timescaledb-postgis:1.3.1-pg11
+FROM timescale/timescaledb:1.7.4-pg11
+#FROM timescale/timescaledb-postgis:12.1.0-pg1
 
 LABEL MAINTAINER BukTon
 

--- a/timescaledb/conf/patroni.yml
+++ b/timescaledb/conf/patroni.yml
@@ -17,6 +17,8 @@ bootstrap:
         maximum_lag_on_failover: 1048576
         postgresql:
             use_pg_rewind: true
+            parameters:
+              shared_preload_libraries: timescaledb
 
     initdb:
     - encoding: UTF8

--- a/timescaledb/conf/patroni2.yml
+++ b/timescaledb/conf/patroni2.yml
@@ -17,6 +17,8 @@ bootstrap:
         maximum_lag_on_failover: 1048576
         postgresql:
             use_pg_rewind: true
+            parameters:
+              shared_preload_libraries: timescaledb
 
     initdb:
     - encoding: UTF8

--- a/timescaledb/conf/patroni3.yml
+++ b/timescaledb/conf/patroni3.yml
@@ -17,6 +17,8 @@ bootstrap:
         maximum_lag_on_failover: 1048576
         postgresql:
             use_pg_rewind: true
+            parameters:
+              shared_preload_libraries: timescaledb
 
     initdb:
     - encoding: UTF8


### PR DESCRIPTION
without psycopg2

```
:~/docker-lab-timescaledb/timescaledb$ docker run -it c776abda64aa
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.8/site-packages/patroni/__init__.py", line 138, in patroni_main
    abstract_main(Patroni, schema)
  File "/usr/lib/python3.8/site-packages/patroni/daemon.py", line 75, in abstract_main
    from .config import Config, ConfigParseError
  File "/usr/lib/python3.8/site-packages/patroni/config.py", line 13, in <module>
    from patroni.postgresql.config import CaseInsensitiveDict, ConfigHandler
  File "/usr/lib/python3.8/site-packages/patroni/postgresql/__init__.py", line 3, in <module>
    import psycopg2
ModuleNotFoundError: No module named 'psycopg2'

```

with psycopg2

```
~/docker-lab-timescaledb/timescaledb$ docker build - < Dockerfile
Sending build context to Docker daemon  3.072kB
Step 1/14 : FROM timescale/timescaledb:latest-pg11
 ---> 240f4dd454bd
Step 2/14 : LABEL MAINTAINER BukTon
 ---> Using cache
 ---> 4c874b92a9fc
Step 3/14 : RUN echo "**** install Python ****" &&     apk add --no-cache python3 python3-dev &&     if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi &&         echo "**** install pip ****" &&     python3 -m ensurepip &&     rm -r /usr/lib/python*/ensurepip &&     pip3 install --no-cache --upgrade pip setuptools wheel &&     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi
 ---> Using cache
 ---> a7413dc49bf0
Step 4/14 : RUN apk update && apk --no-cache add gcc g++ libpq linux-headers curl
 ---> Using cache
 ---> 848cef731f86
Step 5/14 : RUN pip3 install --upgrade pi
 ---> Using cache
 ---> 4c90826f24e4
Step 6/14 : RUN pip install psycopg2
 ---> Running in 4959350e7596
Collecting psycopg2
  Downloading psycopg2-2.8.6.tar.gz (383 kB)
Building wheels for collected packages: psycopg2
  Building wheel for psycopg2 (setup.py): started
  Building wheel for psycopg2 (setup.py): finished with status 'done'
  Created wheel for psycopg2: filename=psycopg2-2.8.6-cp38-cp38-linux_x86_64.whl size=442787 sha256=cf554d11cfd1e72e4d74f4460bbc114dc3bfb0f923561a137bd4f38669c22808
  Stored in directory: /root/.cache/pip/wheels/70/5e/69/8a020d78c09043156a7df0b64529e460fbd922ca065c4b795c
Successfully built psycopg2
Installing collected packages: psycopg2
Successfully installed psycopg2-2.8.6
Removing intermediate container 4959350e7596
 ---> 4e26ef893a6f
Step 7/14 : RUN pip install patroni
 ---> Running in 97e0508bfbe6
Collecting patroni
  Downloading patroni-2.0.2-py3-none-any.whl (211 kB)
Collecting six>=1.7
  Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting click>=4.1
  Downloading click-7.1.2-py2.py3-none-any.whl (82 kB)
Collecting urllib3!=1.21,>=1.19.1
  Downloading urllib3-1.26.3-py2.py3-none-any.whl (137 kB)
Collecting psutil>=2.0.0
  Downloading psutil-5.8.0.tar.gz (470 kB)
Collecting prettytable>=0.7
  Downloading prettytable-2.1.0-py3-none-any.whl (22 kB)
Collecting ydiff>=1.2.0
  Downloading ydiff-1.2.tar.gz (42 kB)
Collecting python-dateutil
  Downloading python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
Collecting PyYAML
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Collecting wcwidth
  Downloading wcwidth-0.2.5-py2.py3-none-any.whl (30 kB)
Building wheels for collected packages: psutil, ydiff, PyYAML
  Building wheel for psutil (setup.py): started
  Building wheel for psutil (setup.py): finished with status 'done'
  Created wheel for psutil: filename=psutil-5.8.0-cp38-cp38-linux_x86_64.whl size=271778 sha256=255cee259336e3e6c0d33c042ec86a17000a729dc14915f1d5df301df117dc51
  Stored in directory: /root/.cache/pip/wheels/a9/92/74/7694cd5d3f10ea335ef507c10e877b2150de20975a986782b9
  Building wheel for ydiff (setup.py): started
  Building wheel for ydiff (setup.py): finished with status 'done'
  Created wheel for ydiff: filename=ydiff-1.2-py3-none-any.whl size=16631 sha256=501c113656b115c718fc3c28118568355ca27f42639c986fa1e906123b69a0f9
  Stored in directory: /root/.cache/pip/wheels/3b/64/6b/1fffe46e533173749dd54bd9cf053291ae9d2bcc53dffba1ff
  Building wheel for PyYAML (PEP 517): started
  Building wheel for PyYAML (PEP 517): finished with status 'done'
  Created wheel for PyYAML: filename=PyYAML-5.4.1-cp38-cp38-linux_x86_64.whl size=45641 sha256=55af95f1856609fa445d260af4c3203883cc50e16c2af35e7e06b4613298860d
  Stored in directory: /root/.cache/pip/wheels/dd/c5/1d/5d7436173d3efd4a14dcb510eb0b29525ecb6b0e41489e716e
Successfully built psutil ydiff PyYAML
Installing collected packages: wcwidth, six, ydiff, urllib3, PyYAML, python-dateutil, psutil, prettytable, click, patroni
Successfully installed PyYAML-5.4.1 click-7.1.2 patroni-2.0.2 prettytable-2.1.0 psutil-5.8.0 python-dateutil-2.8.1 six-1.15.0 urllib3-1.26.3 wcwidth-0.2.5 ydiff-1.2
Removing intermediate container 97e0508bfbe6
 ---> 8efe1f0531cd
Step 8/14 : RUN pip install python-etcd
 ---> Running in 5b976feec0c8
Collecting python-etcd
  Downloading python-etcd-0.4.5.tar.gz (37 kB)
Requirement already satisfied: urllib3>=1.7.1 in /usr/lib/python3.8/site-packages (from python-etcd) (1.26.3)
Collecting dnspython>=1.13.0
  Downloading dnspython-2.1.0-py3-none-any.whl (241 kB)
Building wheels for collected packages: python-etcd
  Building wheel for python-etcd (setup.py): started
  Building wheel for python-etcd (setup.py): finished with status 'done'
  Created wheel for python-etcd: filename=python_etcd-0.4.5-py3-none-any.whl size=38501 sha256=48e6393b39d08b5cd7d166ea87f5c9156fc156017ce42f13718e5ee8b098ff21
  Stored in directory: /root/.cache/pip/wheels/10/fa/7a/8ee59bc1789d1a1efffb172d6efbd0d24c5b85ec7ddce32ee4
Successfully built python-etcd
Installing collected packages: dnspython, python-etcd
Successfully installed dnspython-2.1.0 python-etcd-0.4.5
Removing intermediate container 5b976feec0c8
 ---> b58ce7423a55
Step 9/14 : RUN ln -s /usr/local/bin/pg_* /usr/sbin/
 ---> Running in e8f36f7a2ea8
Removing intermediate container e8f36f7a2ea8
 ---> 979d087d1a84
Step 10/14 : RUN mkdir -p /data/patroni   && chown postgres:postgres /data/patroni   && chown postgres:postgres /data   && chmod 700 /data/patroni
 ---> Running in 464ca99b94a1
Removing intermediate container 464ca99b94a1
 ---> e55d1313c98e
Step 11/14 : USER postgres
 ---> Running in 98c7f0904195
Removing intermediate container 98c7f0904195
 ---> c646fb52c0d5
Step 12/14 : WORKDIR /data/patroni
 ---> Running in 68711a0db419
Removing intermediate container 68711a0db419
 ---> bf822d29210c
Step 13/14 : EXPOSE 5432 8008
 ---> Running in 0847fe6a18e2
Removing intermediate container 0847fe6a18e2
 ---> c57b7f10b663
Step 14/14 : CMD patroni /etc/patroni.yml
 ---> Running in 54f0a593e241
Removing intermediate container 54f0a593e241
 ---> c5e5712509a2
Successfully built c5e5712509a2

```